### PR TITLE
Using bind_rows() instead of rbind_all()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Multi-Level Vector Autoregression
 Version: 0.4.3
 Depends: R (>= 3.3.0)
-Imports: lme4,  arm, qgraph, dplyr, clusterGeneration, mvtnorm, corpcor, plyr, abind, methods, parallel, MplusAutomation, graphicalVAR
+Imports: lme4,  arm, qgraph, dplyr (>= 0.5.0), clusterGeneration, mvtnorm, corpcor, plyr, abind, methods, parallel, MplusAutomation, graphicalVAR
 Author: Sacha Epskamp, Marie K. Deserno and Laura F. Bringmann
 Maintainer: Sacha Epskamp <mail@sachaepskamp.com>
 Description: Estimates the multi-level vector autoregression model on time-series data.

--- a/R/mlVAR0.R
+++ b/R/mlVAR0.R
@@ -320,11 +320,11 @@ mlVAR0 <- function(
   
   if (estimator=="lmmlasso"){
     out <- list(
-      fixedEffects = as.data.frame(rbind_all(lapply(NodeWise_Results,"[[","Coef")))
-      # se.fixedEffects = as.data.frame(rbind_all(lapply(NodeWise_Results,"[[","se.Coef"))),
+      fixedEffects = as.data.frame(bind_rows(lapply(NodeWise_Results,"[[","Coef")))
+      # se.fixedEffects = as.data.frame(bind_rows(lapply(NodeWise_Results,"[[","se.Coef"))),
       # randomEffects =  ranPerID,
-      # randomEffectsVariance = as.data.frame(rbind_all(lapply(NodeWise_Results,"[[","Variance"))),
-      # pvals = as.data.frame(rbind_all(lapply(NodeWise_Results,"[[","pvals"))),
+      # randomEffectsVariance = as.data.frame(bind_rows(lapply(NodeWise_Results,"[[","Variance"))),
+      # pvals = as.data.frame(bind_rows(lapply(NodeWise_Results,"[[","pvals"))),
       # pseudologlik = logLik,
       # df = df,
       # BIC = BIC,
@@ -350,15 +350,15 @@ mlVAR0 <- function(
   
   
   ranlist <- lapply(NodeWise_Results,"[[","ranPerID")
-  ranPerID <- lapply(lapply(seq_along(ranlist[[1]]),function(i)lapply(ranlist,function(x)as.data.frame(x[[i]]))),function(xx)as.data.frame(rbind_all(xx)))
+  ranPerID <- lapply(lapply(seq_along(ranlist[[1]]),function(i)lapply(ranlist,function(x)as.data.frame(x[[i]]))),function(xx)as.data.frame(bind_rows(xx)))
 
   # Output:
   out <- list(
-    fixedEffects = as.data.frame(rbind_all(lapply(NodeWise_Results,"[[","Coef"))),
-    se.fixedEffects = as.data.frame(rbind_all(lapply(NodeWise_Results,"[[","se.Coef"))),
+    fixedEffects = as.data.frame(bind_rows(lapply(NodeWise_Results,"[[","Coef"))),
+    se.fixedEffects = as.data.frame(bind_rows(lapply(NodeWise_Results,"[[","se.Coef"))),
     randomEffects =  ranPerID,
-    randomEffectsVariance = as.data.frame(rbind_all(lapply(NodeWise_Results,"[[","Variance"))),
-    pvals = as.data.frame(rbind_all(lapply(NodeWise_Results,"[[","pvals"))),
+    randomEffectsVariance = as.data.frame(bind_rows(lapply(NodeWise_Results,"[[","Variance"))),
+    pvals = as.data.frame(bind_rows(lapply(NodeWise_Results,"[[","pvals"))),
 #     pseudologlik = logLik,
 #     df = df,
 #     BIC = BIC,

--- a/R/mlVARmodel.R
+++ b/R/mlVARmodel.R
@@ -366,7 +366,7 @@ mlVARsim0 <- function(
   }
 
   ### Simulate data:
-  Data <- dplyr::rbind_all(lapply(seq_len(nPerson),function(i){
+  Data <- dplyr::bind_rows(lapply(seq_len(nPerson),function(i){
     Data <- simulateVAR(Betas[[i]],lags=1,Nt=nTime,residuals = Resids[[i]])
     Data$ID <- i
     return(Data)

--- a/R/movingWindow.R
+++ b/R/movingWindow.R
@@ -57,7 +57,7 @@ movingWindow <- function(
   if (estimator=="lmmlasso"){
     FullResults <- list(
       Result = lapply(Results,"[[","Result"),
-      Coef = Results %>% lapply("[[","Coef") %>% rbind_all %>% group_by_("dep")  %>%
+      Coef = Results %>% lapply("[[","Coef") %>% bind_rows() %>% group_by_("dep")  %>%
         summarize_each(funs(mean(., na.rm=TRUE)))
     )
 
@@ -66,26 +66,26 @@ movingWindow <- function(
     FullResults <- list(
       Result = lapply(Results,"[[","Result"),
       formula = lapply(Results,"[[","formula"),
-      FixEf = Results %>% lapply("[[","FixEf") %>% rbind_all %>% 
+      FixEf = Results %>% lapply("[[","FixEf") %>% bind_rows() %>% 
         summarize_each(funs(mean(., na.rm=TRUE))),
-      FixEf_SE = Results %>% lapply("[[","FixEf_SE") %>% rbind_all %>% 
+      FixEf_SE = Results %>% lapply("[[","FixEf_SE") %>% bind_rows() %>% 
         summarize_each(funs(mean(., na.rm=TRUE))),
-      Coef = Results %>% lapply("[[","Coef") %>% rbind_all %>% group_by_("dep")  %>%
+      Coef = Results %>% lapply("[[","Coef") %>% bind_rows() %>% group_by_("dep")  %>%
         summarize_each(funs(mean(., na.rm=TRUE))),
-      se.Coef = Results %>% lapply("[[","se.Coef") %>% rbind_all %>%group_by_("dep")  %>%
+      se.Coef = Results %>% lapply("[[","se.Coef") %>% bind_rows() %>%group_by_("dep")  %>%
         summarize_each(funs(mean(., na.rm=TRUE))),
-      pvals = Results %>% lapply("[[","pvals") %>% rbind_all %>% group_by_("dep")  %>%
+      pvals = Results %>% lapply("[[","pvals") %>% bind_rows() %>% group_by_("dep")  %>%
         summarize_each(funs(mean(., na.rm=TRUE))),
       ranEffects = Results %>% lapply("[[", "ranEffects") %>% lapply(function(x){
         x <- x[[1]]
         x$id <- seq_len(nrow(x))
         x
-      }) %>% rbind_all %>% group_by(id) %>% summarize_each(funs(mean(., na.rm=TRUE))),
+      }) %>% bind_rows() %>% group_by(id) %>% summarize_each(funs(mean(., na.rm=TRUE))),
       ranPerID = lapply(seq_along(Results[[1]]$ranPerID), function(i){
         Results %>% lapply(function(x)x$ranPerID[[i]]) %>% 
-          rbind_all %>% group_by_("dep") %>% summarize_each(funs(mean(., na.rm=TRUE)))
+          bind_rows() %>% group_by_("dep") %>% summarize_each(funs(mean(., na.rm=TRUE)))
       }),
-      Variance = Results %>% lapply("[[","Variance") %>% rbind_all %>% group_by_("dep") %>% 
+      Variance = Results %>% lapply("[[","Variance") %>% bind_rows() %>% group_by_("dep") %>% 
         summarize_each(funs(mean(., na.rm=TRUE)))
     )
   }


### PR DESCRIPTION
We're https://github.com/tidyverse/dplyr/issues/4579 in the process of releasing dplyr 0.8.4 and this package fail at our reverse dependency checks because the `dplyr::rbind_all()` function has been formally removed after being deprecated for many versions. 

We might revert that decision because it affects a handful of packages, but in any case even if `rbind_all()` stays a little longer, you still should use `bind_rows()` instead. 

````
# mlVAR

<details>

* Version: 0.4.3
* Source code: https://github.com/cran/mlVAR
* Date/Publication: 2019-06-20 17:00:03 UTC
* Number of recursive dependencies: 110

Run `revdep_details(,"mlVAR")` for more info

</details>

## Newly broken

*   checking dependencies in R code ... NOTE
    ```
    Missing or unexported object: ‘dplyr::rbind_all’
    ```

*   checking R code for possible problems ... NOTE
    ```
    mlVAR0: no visible global function definition for ‘rbind_all’
    mlVAR0 : <anonymous>: no visible global function definition for
      ‘rbind_all’
    movingWindow: no visible binding for global variable ‘rbind_all’
    movingWindow : <anonymous>: no visible binding for global variable
      ‘rbind_all’
    Undefined global functions or variables:
      rbind_all
    ```

````