### PR TITLE
Small improvements to `mlVARsim()`

### DIFF
--- a/R/mlVARmodel.R
+++ b/R/mlVARmodel.R
@@ -47,7 +47,7 @@ simGraph <- function(
 # 3. Shrink all beta's untill all eigens are in unit circle.
 
 
-mlVARsim <- function(
+mlVARsim_test <- function(
   # Simulation setup:
   nPerson = 10, # # of persons.
   nNode = 5, # # of nodes 
@@ -97,7 +97,7 @@ mlVARsim <- function(
   # Omega <- genPositiveDefMat(nNode + nTemporal, "onion", rangeVar = c(1,1))$Sigma
   
   # Generate SD and scale:
-  SD <- runif(nNode + nTemporal, c(rep(mu_SD[1],nNode),rep(init_beta_SD[1],nNode)), c(rep(mu_SD[2],nNode),rep(init_beta_SD[2],nNode)))
+  SD <- runif(nNode + nTemporal, c(rep(mu_SD[1],nNode),rep(init_beta_SD[1],nTemporal)), c(rep(mu_SD[2],nNode),rep(init_beta_SD[2],nTemporal)))
   Omega <- diag(SD) %*%Omega %*% diag(SD)
 
   # Generate fixed contemporaneous:

--- a/R/mlVARmodel.R
+++ b/R/mlVARmodel.R
@@ -47,7 +47,7 @@ simGraph <- function(
 # 3. Shrink all beta's untill all eigens are in unit circle.
 
 
-mlVARsim_test <- function(
+mlVARsim <- function(
   # Simulation setup:
   nPerson = 10, # # of persons.
   nNode = 5, # # of nodes 
@@ -63,11 +63,13 @@ mlVARsim_test <- function(
   init_beta_SD = c(0.1,1),
   fixedMuSD = 1,
   shrink_fixed = 0.9,
-  shrink_deviation = 0.9
+  shrink_deviation = 0.9,
+  beta_sparsity = 0.5,
+  pcor_sparsity = 0.5
 ){
   contemporaneous <- "wishart"
   # contemporaneous <- match.arg(contemporaneous)
-  GGMsparsity = 0.5
+  GGMsparsity = pcor_sparsity
   
   if (length(nTime)==1){
     nTime <- rep(nTime,nPerson)
@@ -132,8 +134,10 @@ mlVARsim_test <- function(
   mu_fixed <- rnorm(nNode,0,fixedMuSD)
   # Generate fixed betas:
   beta_fixed <- rnorm(nTemporal,0)
-  # set weakest 50% to zero:
-  beta_fixed[order(abs(beta_fixed))[1:round(nTemporal/2)]] <- 0
+  # set weakest beta_sparsity*100% to zero:
+  if(beta_sparsity != 0){
+    beta_fixed[order(abs(beta_fixed))[1:round(nTemporal * beta_sparsity)]] <- 0
+  }
   # Include auto-regressions:
   mat <- matrix(0,nNode,nNode*lag)
   diag(mat) <- 1

--- a/man/mlVARsim.Rd
+++ b/man/mlVARsim.Rd
@@ -10,7 +10,7 @@ Simulates an mlVAR model and data with a random variance-covariance matrix for t
 \usage{
 mlVARsim(nPerson = 10, nNode = 5, nTime = 100, lag = 1, thetaVar = rep(1,nNode),
 DF_theta = nNode * 2, mu_SD = c(1, 1), init_beta_SD = c(0.1, 1), fixedMuSD = 1, 
-shrink_fixed = 0.9, shrink_deviation = 0.9)
+shrink_fixed = 0.9, shrink_deviation = 0.9, beta_sparsity = 0.5, pcor_sparsity = 0.5)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -47,6 +47,13 @@ Shrinkage factor for shrinking the fixed effects if the VAR model is not station
   \item{shrink_deviation}{
 Shrinkage factor for shrinking the random effects variance if the VAR model is not stationary
 }
+  \item{beta_sparsity}{
+Proportion of edges in the temporal network that are set to zero
+}
+  \item{pcor_sparsity}{
+Proportion of edges in the contemporaneous network that are set to zero
+}
+
 }
 \author{
 Sacha Epskamp (mail@sachaepskamp.com)


### PR DESCRIPTION
# Description
- Fixed small error where the random effects SD wasn't indexed correctly
- Added the possibility to manually set the sparsity of the temporal and contemporaneous matrices (and updated the documentation accordingly)

This closes #22

# Example/small test
The function now returns the same SD for all columns of the temporal matrix, as intended: 
```r
set.seed(4321)
library(mlVAR)
sim <- mlVARsim(
  nPerson = 100, 
  nNode = 4, 
  nTime = 100, 
  init_beta_SD = c(1, 1)
  )
sim$model$Beta$SD[,,1]
``` 
```
          [,1]      [,2]      [,3]      [,4]
[1,] 0.2287679 0.2287679 0.2287679 0.2287679
[2,] 0.2287679 0.2287679 0.2287679 0.2287679
[3,] 0.2287679 0.2287679 0.2287679 0.2287679
[4,] 0.2287679 0.2287679 0.2287679 0.2287679
```